### PR TITLE
Allow batching of partials through folders

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 var gutil = require('gulp-util');
 var through = require('through2');
 var Handlebars = require('handlebars');
+var fs = require('fs');
 
 module.exports = function (data, opts) {
 
@@ -21,13 +22,20 @@ module.exports = function (data, opts) {
 	// Go through a partials directory array
 	if(options.batch){
 		// Allow single string
-		if(typeof options.batch === 'string') {
-			Handlebars.registerPartials(options.batch);
-		} else {
-			for(var i = 0, l = options.batch.length, b = options.batch[i]; i < l; i++) {
-				Handlebars.registerPartials(b);
-			}
-		}
+		if(typeof options.batch === 'string') options.batch = [options.batch];
+			
+		options.batch.forEach(function (b) {
+			var filenames = fs.readdirSync(b);
+
+			filenames.forEach(function (filename) {
+				// Needs a better name extractor (maybe with the path module)
+				var name = filename.split('.')[0];
+				// Don't allow hidden files
+				if(!name.length) return;
+				var template = fs.readFileSync(b + '/' + filename, 'utf8');
+				Handlebars.registerPartial(b.split('/').pop() + '/' + name, template);
+			});
+		});
 	}
 
 


### PR DESCRIPTION
Read passed in directories for useable files and turn them into useable partials.

Gulpfile:

``` javascript
...
.pipe(handlebars({}, {
    batch: ['templates/layout', 'templates/partials']
}))
...
```

Will register all found files as `parentDir/fileNameWithoutExtension`.

Some templatefile:

``` html
{{> layout/header}}
...
{{> partials/bottom_menu}}
{{> layout/footer}}
```

Can probably be improved for broader usage though, but this suits my needs and works.
If this doesn't fit into what you had in mind for your module, I'll try using my fork and maybe publish it as a separate module all together.
