### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ npm install --save-dev gulp-compile-handlebars
 ```js
 var gulp = require('gulp');
 var handlebars = require('gulp-compile-handlebars');
+var rename = require('gulp-rename');
 
 gulp.task('default', function () {
 	var templateData = {


### PR DESCRIPTION
Example gulpfile uses `rename`, but `rename` is not defined in the list of required modules.
