### PR TITLE
Add `@/at` format to import helpers from template

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,130 @@ var Handlebars = require('handlebars');
 var fs = require('fs');
 var path = require("path");
 
+
+/**
+ * For handling unknown partials
+ * @method mockPartials
+ * @param  {string}     content Contents of handlebars file
+ */
+var mockPartials = function(content){
+	var regex = /{{> (.*)}}/gim, match, partial;
+	if(content.match(regex)){
+		while((match = regex.exec(content)) !== null){
+			partial = match[1];
+			//Only register an empty partial if the partial has not already been registered
+			if(!Handlebars.partials.hasOwnProperty(partial)){
+				Handlebars.registerPartial(partial, '');
+			}
+		}
+	}
+};
+
+// options: 
+// ```
+//	helpersAtPathMap: {
+//		'helpers': './src/js/hbs-helpers/'
+//	}
+// {{@helpers/slugify.helper
+// {{#@helpers/include.helper}}...{{/helpers/include.helper}}
+var registerAtPathHelpers = function(content, basePathMap)
+{
+	var includeHelpersRegex = /{{@([a-zA-Z-0-9\.\/\~]+)/g;
+	var includeBlockHelpersRegex = /{{#@([a-zA-Z-0-9\.\/\~]+)/g;
+	var closingIncludeBlockHelpers = /{{(~?)\/([a-zA-Z-0-9\.\/\~]+)/g;
+
+
+	// replace internal requires with helper form
+	var sanitize = function(name) {
+		return name.replace('/', '-').replace('.', '').replace('~', '_');
+	};
+
+	// Grab all of the helpers out of the template
+	var helpers = [];
+	// Work out the normal helpers
+	content = content.replace(includeHelpersRegex, function(match, dep) {
+		helpers.push(dep);
+		return '{{' + sanitize(dep);
+	});
+	// Work out the block helpers
+	content = content.replace(includeBlockHelpersRegex, function(match, dep) {
+		var helperId = dep;
+		helpers.push(helperId);
+		return '{{#' + sanitize(helperId);
+	});
+	// Work out closing to the block helper {{/helper}}
+	content = content.replace(closingIncludeBlockHelpers, function(match, tilde, dep) {
+		return '{{' + tilde + '/' + sanitize(dep);
+	});
+
+	var arrayUnique = function(a) {
+		return a.reduce(function(p, c) {
+			if (p.indexOf(c) < 0) p.push(c);
+			return p;
+		}, []);
+	};
+
+	// No repeats (because it is unnecessary)
+	helpers = arrayUnique(helpers);
+
+	// We can only
+	if(Object.keys(basePathMap).length > 0)
+	{
+		// Register the helpers
+		for (var i = 0; i < helpers.length; i++)
+		{
+			var helperPath = helpers[i];
+
+			// Replace any defined module names with the appropriate relative paths
+			Object.keys(basePathMap).forEach(function(mapKey, index, array) {
+				var basePath = basePathMap[mapKey];
+				helperPath = helperPath.replace(new RegExp("^(" + mapKey + ")/"), basePath);
+			});
+
+			// Turn the path from relative from the calling file to absolute
+			helperPath = path.resolve(process.cwd(), helperPath);
+			if (process.platform === "win32") {
+				// Switch backslash to forward slash
+				helperPath = helperPath.replace(/\\/g, "/");
+			}
+
+
+			var helperFunc = null;
+			try {
+				// Try to get the helper function
+				helperFunc = require(helperPath);
+			} catch(e) {
+
+			}
+			if(helperFunc !== null)
+			{
+				// Actually register the helper, if we could find it
+				Handlebars.registerHelper(sanitize(helpers[i]), helperFunc);
+			}
+		}
+	}
+
+	return content;
+};
+
+var compileHandlebars = function(source, context, opts)
+{
+	var options = opts || {};
+
+	if(options.ignorePartials){
+		mockPartials(source);
+	}
+	source = registerAtPathHelpers(source, options.helpersAtPathMap || {});
+
+	var template = Handlebars.compile(source);
+
+	return template(context);
+};
+
+
 module.exports = function (data, opts) {
+
+	Handlebars.debugIdAsdf = Math.random()*101|0;
 
 	var options = opts || {};
 
@@ -45,6 +168,8 @@ module.exports = function (data, opts) {
 					var name = filename.substr(0, filename.lastIndexOf('.'));
 
 					var template = fs.readFileSync(dir + '/' + filename, 'utf8');
+
+					template = registerAtPathHelpers(template, options.helpersAtPathMap || {});
 					Handlebars.registerPartial(registrationDir + '/' + name, template);
 					// console.log('Registered:', registrationDir + '/' + name)
 				}
@@ -62,111 +187,6 @@ module.exports = function (data, opts) {
 			searchDirForPartials(piece, piece.split('/').pop(), 0);
 		});
 	}
-
-	/**
-	 * For handling unknown partials
-	 * @method mockPartials
-	 * @param  {string}     content Contents of handlebars file
-	 */
-	var mockPartials = function(content){
-		var regex = /{{> (.*)}}/gim, match, partial;
-		if(content.match(regex)){
-			while((match = regex.exec(content)) !== null){
-				partial = match[1];
-				//Only register an empty partial if the partial has not already been registered
-				if(!Handlebars.partials.hasOwnProperty(partial)){
-					Handlebars.registerPartial(partial, '');
-				}
-			}
-		}
-	};
-
-	// options: 
-	// ```
-	//	helpersAtPathMap: {
-	//		'helpers': './src/js/hbs-helpers/'
-	//	}
-	// {{@helpers/slugify.helper
-	// {{#@helpers/include.helper}}...{{/helpers/include.helper}}
-	var registerAtPathHelpers = function(content, basePathMap) 
-	{
-		var includeHelpersRegex = /{{@([a-zA-Z-0-9\.\/\~]+)/g;
-		var includeBlockHelpersRegex = /{{#@([a-zA-Z-0-9\.\/\~]+)/g;
-		var closingIncludeBlockHelpers = /{{(~?)\/([a-zA-Z-0-9\.\/\~]+)/g;
-
-
-		// replace internal requires with helper form
-		var sanitize = function(name) {
-			return name.replace('/', '-').replace('.', '').replace('~', '_');
-		};
-
-		// Grab all of the helpers out of the template
-		var helpers = [];
-		// Work out the normal helpers
-		content = content.replace(includeHelpersRegex, function(match, dep) {
-			helpers.push(dep);
-			return '{{' + sanitize(dep);
-		});
-		// Work out the block helpers
-		content = content.replace(includeBlockHelpersRegex, function(match, dep) {
-			var helperId = dep;
-			helpers.push(helperId);
-			return '{{#' + sanitize(helperId);
-		});
-		// Work out closing to the block helper {{/helper}}
-		content = content.replace(closingIncludeBlockHelpers, function(match, tilde, dep) {
-			return '{{' + tilde + '/' + sanitize(dep);
-		});
-
-		var arrayUnique = function(a) {
-			return a.reduce(function(p, c) {
-				if (p.indexOf(c) < 0) p.push(c);
-				return p;
-			}, []);
-		};
-
-		// No repeats (because it is unnecessary)
-		helpers = arrayUnique(helpers);
-
-		// We can only
-		if(Object.keys(basePathMap).length > 0)
-		{
-			// Register the helpers
-			for (var i = 0; i < helpers.length; i++)
-			{
-				var helperPath = helpers[i];
-
-				// Replace any defined module names with the appropriate relative paths
-				Object.keys(basePathMap).forEach(function(mapKey, index, array) {
-					var basePath = basePathMap[mapKey];
-					helperPath = helperPath.replace(new RegExp("^(" + mapKey + ")/"), basePath);
-				});
-
-				// Turn the path from relative from the calling file to absolute
-				helperPath = path.resolve(process.cwd(), helperPath);
-				if (process.platform === "win32") {
-					// Switch backslash to forward slash
-					helperPath = helperPath.replace(/\\/g, "/");
-				}
-
-
-				var helperFunc = null;
-				try {
-					// Try to get the helper function
-					helperFunc = require(helperPath);
-				} catch(e) {
-
-				}
-				if(helperFunc !== null)
-				{
-					// Actually register the helper, if we could find it
-					Handlebars.registerHelper(sanitize(helpers[i]), helperFunc);
-				}
-			}
-		}
-
-		return content;
-	};
 
 
 	// Go through a partials object
@@ -197,13 +217,10 @@ module.exports = function (data, opts) {
 
 		try {
 			var fileContents = file.contents.toString();
-			if(options.ignorePartials){
-				mockPartials(fileContents);
-			}
-			fileContents = registerAtPathHelpers(fileContents, options.helpersAtPathMap || {});
+			
+			var compiledTemplate = compileHandlebars(fileContents, data, options);
 
-			var template = Handlebars.compile(fileContents);
-			file.contents = new Buffer(template(data));
+			file.contents = new Buffer(compiledTemplate);
 		} catch (err) {
 			this.emit('error', new gutil.PluginError('gulp-compile-handlebars', err));
 		}
@@ -211,4 +228,11 @@ module.exports = function (data, opts) {
 		this.push(file);
 		cb();
 	});
+};
+
+
+module.exports.compile = function(source, context, opts) {
+	var compiledTemplate = compileHandlebars(source, context, opts);
+
+	return compiledTemplate;
 };

--- a/readme.md
+++ b/readme.md
@@ -139,6 +139,20 @@ gulp.task('default', function () {
 ```
 
 
+## Example: Using `module.exports.compile`:
+
+This module also exports `compile` which works exactly the same except returns the compiled template instead of a gulp stream.
+
+*Supports `@/at` helper syntax*
+
+```
+var handlebars = require('gulp-compile-handlebars');
+
+var handlebarsCompileOptions = {};
+
+handlebars.compile(source, context, handlebarsCompileOptions);
+```
+
 ## Options
 
 - __ignorePartials__ : ignores any unknown partials. Useful if you only want to handle part of the file


### PR DESCRIPTION
This allows you to reference helpers directly inside the handlebars template. The `@` format syntax is the same as the [require-hbs plugin from Guy Bedford](https://github.com/guybedford/hbs#helpers).
## Format:

`{{@helpers/myhelper}}`
`{{#@helpers/myblockhelper}}...{{/helpers/myblockhelper}}`

Added path map option(`helpersAtPathMap: {}`) to map a module name (such as "helpers") to a complete path making it easier to reference helpers.

Also added documentation on this new `@` format.

---

Example taken from added documenation to readme.md:
## Example: inline `@/at` helpers
#### `src/hello.handlebars`

``` handlebars
<p>Hello {{firstName}}</p>
<p>HELLO! {{@helpers/capitals.helper firstName}}</p>
{{#@helpers/noop.helper}}
    <p>A block helper that invokes the block as though no helper existed.</p>
{{/helpers/noop}}
{{> footer}}
```
#### `src/js/hbs-helpers/capitals.helper.js`

``` js
module.exports = function(str) {
    return str.toUpperCase();
}
```
#### `src/js/hbs-helpers/noop.helper.js`

``` js
module.exports = function(options) {
    return options.fn(this);
}
```
#### `gulpfile.js`

``` js
var gulp = require('gulp');
var handlebars = require('gulp-compile-handlebars');
var rename = require('gulp-rename');

gulp.task('default', function () {
    var templateData = {
        firstName: 'Kaanon'
    },
    options = {
        ignorePartials: true,
        partials : {
            footer : '<footer>the end</footer>'
        },
        helpersAtPathMap: {
            'helpers': './src/js/hbs-helpers/'
        },
    }

    return gulp.src('src/hello.handlebars')
        .pipe(handlebars(templateData, options))
        .pipe(rename('hello.html'))
        .pipe(gulp.dest('dist'));
});
```
#### `dist/hello.html`

``` html
<p>Hello Kaanon</p>
<p>HELLO! KAANON</p>
<p>A block helper that invokes the block as though no helper existed.</p>
<footer>the end</footer>
```

---

Currently, in the current master branch of this project, the only way to batch helpers is to do something like this:

```
var glob = require("glob");
var parsePath = require('parse-filepath');
var compileHandlebars = require('gulp-compile-handlebars');

//...
.pipe(compileHandlebars({/*context*/}, {
    helpers : (function() {
        var helpers = {};
        // Get a list of all the helpers in the folder
        var helperFiles = glob.sync("./src/js/hbs-helpers/*.js", {});
        helperFiles.forEach(function(filePath, index, array) {
            var pathParts = parsePath(filePath);
            try {
                helpers[pathParts.name] = require(filePath);
            } catch(e) {

            }
        });

        //console.log(helpers);
        return helpers;
    })()
}))
```
