### PR TITLE
pass in handlebars-engine options

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,9 @@ var Handlebars = require('handlebars');
 var fs = require('fs');
 var extend = require('util')._extend;
 
-module.exports = function (data, opts, handlebarsOpts) {
+module.exports = function (data, opts) {
 
-	var options = opts || {},
-	    handlebarsOpts = handlebarsOpts || {};
+	var options = opts || {};
 	    
 	//Go through a partials object
 	if(options.partials){
@@ -114,7 +113,7 @@ module.exports = function (data, opts, handlebarsOpts) {
 			if(file.data){
 				_data = extend(_data, file.data);
 			}
-			var template = Handlebars.compile(fileContents, handlebarsOpts);
+			var template = Handlebars.compile(fileContents, options.compile);
 			file.contents = new Buffer(template(_data));
 		} catch (err) {
 			this.emit('error', new gutil.PluginError('gulp-compile-handlebars', err));

--- a/index.js
+++ b/index.js
@@ -4,9 +4,11 @@ var Handlebars = require('handlebars');
 var fs = require('fs');
 var extend = require('util')._extend;
 
-module.exports = function (data, opts) {
+module.exports = function (data, opts, handlebarsOpts) {
 
-	var options = opts || {};
+	var options = opts || {},
+	    handlebarsOpts = handlebarsOpts || {};
+	    
 	//Go through a partials object
 	if(options.partials){
 		for(var p in options.partials){
@@ -112,7 +114,7 @@ module.exports = function (data, opts) {
 			if(file.data){
 				_data = extend(_data, file.data);
 			}
-			var template = Handlebars.compile(fileContents);
+			var template = Handlebars.compile(fileContents, handlebarsOpts);
 			file.contents = new Buffer(template(_data));
 		} catch (err) {
 			this.emit('error', new gutil.PluginError('gulp-compile-handlebars', err));

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var Handlebars = require('handlebars');
 var fs = require('fs');
 var extend = require('util')._extend;
 
-module.exports = function (data, opts) {
+function handlebars(data, opts) {
 
 	var options = opts || {};
 	    
@@ -122,4 +122,9 @@ module.exports = function (data, opts) {
 		this.push(file);
 		cb();
 	});
-};
+}
+
+// Expose the Handlebars object
+handlebars.Handlebars = Handlebars;
+
+module.exports = handlebars;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-compile-handlebars",
-  "version": "0.4.4",
+  "version": "0.5.0",
   "description": "Compile Handlebars templates to file - gulp plugin",
   "license": "MIT",
   "repository": "kaanon/gulp-compile-handlebars",

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ npm install --save-dev gulp-compile-handlebars
 ### `src/hello.handlebars`
 
 ```handlebars
-{{> partials/header}}
+{{> header}}
 <p>Hello {{firstName}}</p>
 <p>HELLO! {{capitals firstName}}</p>
 {{> footer}}

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,15 @@ gulp.task('default', function () {
 - __helpers__: javascript functions to stand in for helpers used in the handlebars files
 - __compile__: compile options. See [handlebars reference](http://handlebarsjs.com/reference.html#base-compile) for possible values
 
+## handlebars.Handlebars
+
+You can access the Handlebars library from the `handlebars.Handlebars` property.
+
+```js
+var handlebars = require('gulp-compile-handlebars');
+var safestring = new handlebars.Handlebars.SafeString('<strong>HELLO! KAANON</strong>');
+```
+
 ## Works with gulp-data
 
 Use gulp-data to pass a data object to the template based on the handlebars file being processed.

--- a/readme.md
+++ b/readme.md
@@ -76,6 +76,7 @@ gulp.task('default', function () {
 - __partials__ : Javascript object that will fill in partials using strings
 - __batch__ : Javascript array of filepaths to use as partials
 - __helpers__: javascript functions to stand in for helpers used in the handlebars files
+- __compile__: compile options. See [handlebars reference](http://handlebarsjs.com/reference.html#base-compile) for possible values
 
 ## Works with gulp-data
 


### PR DESCRIPTION
We needed to pass in some options to the Handlebars engine. So we just added the ability to pass an options object which just get passed-trough to Handlebars when compiling.