### PR TITLE
Export the Handlebars library

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var Handlebars = require('handlebars');
 var fs = require('fs');
 var extend = require('util')._extend;
 
-module.exports = function (data, opts) {
+function handlebars(data, opts) {
 
 	var options = opts || {};
 	//Go through a partials object
@@ -121,4 +121,9 @@ module.exports = function (data, opts) {
 		this.push(file);
 		cb();
 	});
-};
+}
+
+// Expose the Handlebars object
+handlebars.Handlebars = Handlebars;
+
+module.exports = handlebars;

--- a/readme.md
+++ b/readme.md
@@ -77,6 +77,15 @@ gulp.task('default', function () {
 - __batch__ : Javascript array of filepaths to use as partials
 - __helpers__: javascript functions to stand in for helpers used in the handlebars files
 
+## handlebars.Handlebars
+
+You can access the Handlebars library from the `handlebars.Handlebars` property.
+
+```js
+var handlebars = require('gulp-compile-handlebars');
+var safestring = new handlebars.Handlebars.SafeString('<strong>HELLO! KAANON</strong>');
+```
+
 ## Works with gulp-data
 
 Use gulp-data to pass a data object to the template based on the handlebars file being processed.


### PR DESCRIPTION
Export the Handlebars library so that you don't have to require Handlebars separately. This also ensures that you are using the same version of Handlebars.