### PR TITLE
Handle partial filenames starting with an underscore.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,9 +35,9 @@ function handlebars(data, opts) {
 	};
 
 	var partialName = function (filename, base) {
-		var name = filename.substr(filename.charAt(0) === '_' ? 1 : 0, filename.lastIndexOf('.'));
+		var name = filename.substr(0, filename.lastIndexOf('.'));
 		name = name.replace(new RegExp('^' + base + '\\/'), '');
-		return name;
+		return name.substring(name.charAt(0) === '_' ? 1 : 0);
 	};
 
 	var registerPartial = function (filename, base) {

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ function handlebars(data, opts) {
 	};
 
 	var partialName = function (filename, base) {
-		var name = filename.substr(0, filename.lastIndexOf('.'));
+		var name = filename.substr(filename.charAt(0) === '_' ? 1 : 0, filename.lastIndexOf('.'));
 		name = name.replace(new RegExp('^' + base + '\\/'), '');
 		return name;
 	};


### PR DESCRIPTION
It's a common practice to have partial filenames start with an underscore, so this is a tiny tweak to handle that correctly by removing the underscore from the compiled partial name.