### PR TITLE
package.json handlebars dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "gulp-util": "^3.0.3",
     "through2": "^0.6.3",
-    "handlebars": "^3.0.0"
+    "handlebars": ">=3.0.0"
   },
   "devDependencies": {
     "mocha": "*"


### PR DESCRIPTION
package throws error if there is handlebars@4.X in root and handlebars@3.X in dependencies installed