### PR TITLE
Added windows support. More test cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-compile-handlebars",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Compile Handlebars templates to file - gulp plugin",
   "license": "MIT",
   "repository": "kaanon/gulp-compile-handlebars",

--- a/test/partials/desktop/header-test.hbs
+++ b/test/partials/desktop/header-test.hbs
@@ -1,0 +1,1 @@
+Desktop Header Goes Here

--- a/test/partials/header-test.hbs
+++ b/test/partials/header-test.hbs
@@ -1,0 +1,1 @@
+Header Goes Here

--- a/test/partials/mobile/header-test.hbs
+++ b/test/partials/mobile/header-test.hbs
@@ -1,0 +1,1 @@
+Mobile Header Goes Here

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 'use strict';
 var assert = require('assert');
 var gutil = require('gulp-util');
-var template = require('./index');
+var template = require('../index');
 
 it('should compile Handlebars templates', function (cb) {
 	var stream = template(
@@ -44,6 +44,51 @@ it('should compile Handlebars templates, and ignore unknown partials', function 
 
 	stream.write(new gutil.File({
 		contents: new Buffer('{{> header}}{{#each people}}<li>{{.}}</li>{{/each}} {{toLower message}}')
+	}));
+
+	stream.end();
+});
+
+it('should compile Handlebars templates, and use batched partials', function (cb) {
+	var stream = template({}, { batch: ['test/partials'] });
+
+	stream.on('data', function (data) {
+		assert.equal(data.contents.toString(), 'Header Goes Here');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		contents: new Buffer('{{> header-test}}')
+	}));
+
+	stream.end();
+});
+
+it('should compile Handlebars templates, and use batched NESTED partials', function (cb) {
+	var stream = template({}, { batch: ['test/partials'] });
+
+	stream.on('data', function (data) {
+		assert.equal(data.contents.toString(), 'Mobile Header Goes Here');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		contents: new Buffer('{{> mobile/header-test}}')
+	}));
+
+	stream.end();
+});
+
+it('should compile Handlebars templates, and use multiple batched NESTED partials directories', function (cb) {
+	var stream = template({}, { batch: ['test/partials/desktop', 'test/partials/mobile'] });
+
+	stream.on('data', function (data) {
+		assert.equal(data.contents.toString(), 'Desktop Header Goes Here');
+		cb();
+	});
+
+	stream.write(new gutil.File({
+		contents: new Buffer('{{> desktop/header-test}}')
 	}));
 
 	stream.end();


### PR DESCRIPTION
Took the best of both worlds from https://github.com/kaanon/gulp-compile-handlebars/pull/17 and https://github.com/kaanon/gulp-compile-handlebars/pull/20

Still works for me on *nix, but I don't have a windows box to test.
Ideally the move to the path module should fix any issues with `/` vs `\`
