### PR TITLE
Remove Duplication in README + Question About Helpers

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -87,15 +87,6 @@ var handlebars = require('gulp-compile-handlebars');
 var safestring = new handlebars.Handlebars.SafeString('<strong>HELLO! KAANON</strong>');
 ```
 
-## handlebars.Handlebars
-
-You can access the Handlebars library from the `handlebars.Handlebars` property.
-
-```js
-var handlebars = require('gulp-compile-handlebars');
-var safestring = new handlebars.Handlebars.SafeString('<strong>HELLO! KAANON</strong>');
-```
-
 ## Works with gulp-data
 
 Use gulp-data to pass a data object to the template based on the handlebars file being processed.


### PR DESCRIPTION
"handlebars.Handlebars" section was written twice.

---

With the helpers option, is it possible to include helpers from a npm package (e.g. [handlebars-intl](https://www.npmjs.com/package/handlebars-intl))? Or will I have to handpick the helper functions I need out of the packages?